### PR TITLE
fix: cmdpal - focusing search on mouse click

### DIFF
--- a/client/src/lib/CommandPalette.svelte
+++ b/client/src/lib/CommandPalette.svelte
@@ -246,6 +246,8 @@
     const onCmdMouseUp = () => {
         selectedCommand = undefined;
         isCommandSelected = false;
+
+        searchElement?.focus();
     };
 </script>
 


### PR DESCRIPTION
closes #265 