### PR TITLE
Remove Hosted Service from ChangelogProvider

### DIFF
--- a/api/Controllers/MetaController.cs
+++ b/api/Controllers/MetaController.cs
@@ -11,8 +11,7 @@ public sealed class MetaController(
     VersionProvider versionProvider,
     ChangelogProvider changelogProvider,
     PasteService pasteService,
-    StatsService statsService,
-    IMemoryCache memoryCache)
+    StatsService statsService)
     : ControllerBase
 {
     [HttpGet("version")]
@@ -24,14 +23,7 @@ public sealed class MetaController(
     [HttpGet("releases")]
     public async Task<List<Release>> GetReleases()
     {
-        if (memoryCache.TryGetValue("releases", out List<Release> releases))
-            return releases;
-
-        var updatedReleases = (await changelogProvider.GenerateChangelogAsync()).ToList();
-
-        memoryCache.Set("releases", updatedReleases, DateTimeOffset.Now.AddHours(1));
-
-        return updatedReleases;
+        return (await changelogProvider.GenerateChangelogAsync()).ToList();
     }
 
     [HttpGet("active_pastes")]

--- a/api/Controllers/MetaController.cs
+++ b/api/Controllers/MetaController.cs
@@ -17,7 +17,7 @@ public sealed class MetaController(
     [HttpGet("version")]
     public VersionResponse GetVersion()
     {
-        return new VersionResponse { Version = versionProvider.Version };
+        return new VersionResponse { Version = versionProvider.GetVersion() };
     }
 
     [HttpGet("releases")]

--- a/api/Controllers/MetaController.cs
+++ b/api/Controllers/MetaController.cs
@@ -6,8 +6,8 @@ using pastemyst.Services;
 namespace pastemyst.Controllers;
 
 [ApiController]
-[Route("/api/v3/meta")]
-public class MetaController(
+[Route("api/v3/meta")]
+public sealed class MetaController(
     VersionProvider versionProvider,
     ChangelogProvider changelogProvider,
     PasteService pasteService,

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddHttpLogging(o => {});
 
 builder.Services.AddDistributedMemoryCache();
+builder.Services.AddMemoryCache();
 
 builder.Services.AddSession(options =>
 {
@@ -36,15 +37,8 @@ builder.Services.AddSingleton(s =>
     (IHostedService)s.GetRequiredService<LanguageProvider>()
 );
 
-builder.Services.TryAddSingleton<VersionProvider>();
-builder.Services.AddSingleton(s =>
-    (IHostedService)s.GetRequiredService<VersionProvider>()
-);
-
-builder.Services.TryAddSingleton<ChangelogProvider>();
-builder.Services.AddSingleton(s =>
-    s.GetRequiredService<ChangelogProvider>()
-);
+builder.Services.AddSingleton<VersionProvider>();
+builder.Services.AddSingleton<ChangelogProvider>();
 
 builder.Services.AddScoped<IdProvider>();
 builder.Services.AddScoped<ImageService>();
@@ -107,9 +101,9 @@ var app = builder.Build();
 
 app.UseHttpLogging();
 
-app.UseMiddleware<ExceptionMiddleware>();
-app.UseMiddleware<UserContextMiddleware>();
-app.UseMiddleware<EncryptionMiddleware>();
+// app.UseMiddleware<ExceptionMiddleware>();
+// app.UseMiddleware<UserContextMiddleware>();
+// app.UseMiddleware<EncryptionMiddleware>();
 
 if (app.Environment.IsDevelopment())
 {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -18,7 +18,6 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddHttpLogging(o => {});
 
 builder.Services.AddDistributedMemoryCache();
-builder.Services.AddMemoryCache();
 
 builder.Services.AddSession(options =>
 {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -101,9 +101,9 @@ var app = builder.Build();
 
 app.UseHttpLogging();
 
-// app.UseMiddleware<ExceptionMiddleware>();
-// app.UseMiddleware<UserContextMiddleware>();
-// app.UseMiddleware<EncryptionMiddleware>();
+app.UseMiddleware<ExceptionMiddleware>();
+app.UseMiddleware<UserContextMiddleware>();
+app.UseMiddleware<EncryptionMiddleware>();
 
 if (app.Environment.IsDevelopment())
 {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -43,7 +43,7 @@ builder.Services.AddSingleton(s =>
 
 builder.Services.TryAddSingleton<ChangelogProvider>();
 builder.Services.AddSingleton(s =>
-    (IHostedService)s.GetRequiredService<ChangelogProvider>()
+    s.GetRequiredService<ChangelogProvider>()
 );
 
 builder.Services.AddScoped<IdProvider>();

--- a/api/Services/ChangelogProvider.cs
+++ b/api/Services/ChangelogProvider.cs
@@ -4,61 +4,48 @@ using Release = pastemyst.Models.Release;
 
 namespace pastemyst.Services;
 
-public class ChangelogProvider : IHostedService
+public sealed class ChangelogProvider
 {
-    public List<Release> Releases { get; } = new();
-
-    public async Task StartAsync(CancellationToken cancellationToken)
+    public async Task<IEnumerable<Release>> GenerateChangelogAsync()
     {
         var github = new GitHubClient(new ProductHeaderValue("pastemyst"));
 
         var v2Releases = await github.Repository.Release.GetAll("codemyst", "pastemyst");
         var v3Releases = await github.Repository.Release.GetAll("pastemyst", "pastemyst-v3");
 
-        Releases.AddRange(GenerateChangelog(v3Releases));
-        Releases.AddRange(GenerateChangelog(v2Releases));
+        // Ignore drafts.
+        return
+        [
+            ..v3Releases.Where(x => !x.Draft).Select(ToRelease),
+            ..v2Releases.Where(x => !x.Draft).Select(ToRelease)
+        ];
     }
 
-    public Task StopAsync(CancellationToken cancellationToken)
+    private static Release ToRelease(Octokit.Release release)
     {
-        return Task.CompletedTask;
-    }
-
-    private IEnumerable<Release> GenerateChangelog(IEnumerable<Octokit.Release> releases)
-    {
-        var res = new List<Release>();
-
-        foreach (var release in releases)
+        // If it doesn't have a title use the tag as the title.
+        var title = release.Name;
+        if (string.IsNullOrEmpty(title))
         {
-            // Ignore drafts.
-            if (release.Draft) continue;
-
-            // If it doesn't have a title use the tag as the title.
-            var title = release.Name;
-            if (string.IsNullOrEmpty(title))
-            {
-                title = release.TagName;
-            }
-
-            // Prepend with 'v' if it's missing.
-            if (title[0] != 'v')
-            {
-                title = "v" + title;
-            }
-
-            // Remove ## changelog from older releases.
-            var content = Regex.Replace(release.Body, "(?i)## changelog:?\r\n\r\n", "");
-
-            res.Add(new Release
-            {
-                Url = release.HtmlUrl,
-                Title = title,
-                Content = content,
-                IsPrerelease = release.Prerelease,
-                ReleasedAt = release.PublishedAt
-            });
+            title = release.TagName;
         }
 
-        return res;
+        // Prepend with 'v' if it's missing.
+        if (title[0] != 'v')
+        {
+            title = "v" + title;
+        }
+
+        // Remove ## changelog from older releases.
+        var content = Regex.Replace(release.Body, "(?i)## changelog:?\r\n\r\n", "");
+
+        return new Release
+        {
+            Url = release.HtmlUrl,
+            Title = title,
+            Content = content,
+            IsPrerelease = release.Prerelease,
+            ReleasedAt = release.PublishedAt
+        };
     }
 }

--- a/api/Services/ChangelogProvider.cs
+++ b/api/Services/ChangelogProvider.cs
@@ -6,19 +6,28 @@ namespace pastemyst.Services;
 
 public sealed class ChangelogProvider
 {
+    private List<Release> _releases;
+
     public async Task<IEnumerable<Release>> GenerateChangelogAsync()
     {
+        // If we've cached the releases before, then just return it
+        if (_releases != null)
+            return _releases;
+
+        // Otherwise, fetch it and cache it for subsequent requests
         var github = new GitHubClient(new ProductHeaderValue("pastemyst"));
 
         var v2Releases = await github.Repository.Release.GetAll("codemyst", "pastemyst");
         var v3Releases = await github.Repository.Release.GetAll("pastemyst", "pastemyst-v3");
 
         // Ignore drafts.
-        return
+        _releases =
         [
             ..v3Releases.Where(x => !x.Draft).Select(ToRelease),
             ..v2Releases.Where(x => !x.Draft).Select(ToRelease)
         ];
+
+        return _releases;
     }
 
     private static Release ToRelease(Octokit.Release release)


### PR DESCRIPTION
## What?
Previously, the project used an IHostedService to poll GitHub release when the server is restarted. This can be simplified to a singleton service which caches on the first call to the service.

This PR also removes the redundant service registrations now that it is no longer a hosted service:

```cs
// Old
builder.Services.TryAddSingleton<VersionProvider>();
builder.Services.AddSingleton(s =>
    (IHostedService)s.GetRequiredService<VersionProvider>()
);

// New
builder.Services.AddSingleton<VersionProvider>();
``` 

## Why

Reduce use of IHostedService

## Notes
- Also seals the ``MetaController`` and ``ChangelogProvider`` (sealed by default)