### PR TITLE
fix: ensure empty lines in markdown codeblocks are displayed

### DIFF
--- a/client/src/routes/internal/highlight/+server.ts
+++ b/client/src/routes/internal/highlight/+server.ts
@@ -81,6 +81,10 @@ const highlight = async (
         for (const token of line) {
             lineHtml += `<span style="color: ${token.variants.dark.color}">${he.encode(token.content)}</span>`;
         }
+        // ensure empty lines are rendered
+        if (line.length === 0) {
+            lineHtml += `\n`;
+        }
         lineHtml += `</span>`;
         result += lineHtml;
     }


### PR DESCRIPTION
Closes #814 